### PR TITLE
pip(deps): bump httpx[http2] from 0.25.2 to 0.28.1 updatw

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ffmpeg-python
 gitpython
 hachoir
 heroku3
-httpx[http2]==0.25.2
+httpx[http2]==0.28.1
 motor
 numpy
 opencv-python


### PR DESCRIPTION
Bumps [httpx[http2]](https://github.com/encode/httpx) from 0.25.2 to 0.28.1.
- [Release notes](https://github.com/encode/httpx/releases)
- [Changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)
- [Commits](https://github.com/encode/httpx/compare/0.25.2...0.28.1)

---
updated-dependencies:
- dependency-name: httpx[http2] dependency-version: 0.28.1 dependency-type: direct:production update-type: version-update:semver-minor ...