### PR TITLE
Improve uvloop fallback log

### DIFF
--- a/ShrutiMusic/core/bot.py
+++ b/ShrutiMusic/core/bot.py
@@ -1,12 +1,15 @@
-import uvloop
+from ..logging import LOGGER
 
-uvloop.install()
+try:  # noqa: WPS501 - optional dependency
+    import uvloop
+    uvloop.install()
+except ImportError:  # noqa: WPS440
+    LOGGER(__name__).info("uvloop not installed, using default event loop")
 
 from pyrogram import Client, errors
 from pyrogram.enums import ChatMemberStatus, ParseMode
 
 import config
-from ..logging import LOGGER
 
 
 class Aviax(Client):


### PR DESCRIPTION
## Summary
- log a message when uvloop isn't installed

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m ShrutiMusic` *(fails: No module named 'pyrogram')*


------
https://chatgpt.com/codex/tasks/task_b_6857355de1c88333b6e9b0c119991d1f