### PR TITLE
Fix privacy command text

### DIFF
--- a/strings/helpers.py
+++ b/strings/helpers.py
@@ -153,5 +153,5 @@ HELP_15 = """
 HELP_16 = """
 <b><u>Privacy Command :</b></u>
 
-/Privacy : Display the privacy statement for Sarcastic Bot 
+/privacy : Display the privacy statement for Sirion Bot
 """


### PR DESCRIPTION
## Summary
- update privacy command text in documentation

## Testing
- `grep -n "privacy statement" -n strings/helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_6857336dc8908333adc727272074a6b5