### PR TITLE
Fix missing traceback import

### DIFF
--- a/ShrutiMusic/utils/thumbnails.py
+++ b/ShrutiMusic/utils/thumbnails.py
@@ -9,6 +9,7 @@ import aiofiles
 import aiohttp
 from PIL import Image, ImageDraw, ImageEnhance, ImageFilter, ImageFont
 from youtubesearchpython.__future__ import VideosSearch
+import traceback
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
## Summary
- add missing `traceback` import for thumbnail generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68573202a72c83338380fa1a8b3656d6