### PR TITLE
Add formatter tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ Use our Session Generator Bot: [@tseries_musicbot](https://t.me/eluzoBot)
 - **Can't join voice chat**: Make sure the bot is an admin with voice chat permissions
 - **API Issues**: Double check your API_ID and API_HASH
 
+## 🧪 Running Tests
+
+To run the test suite locally, install the project dependencies and `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```
+
 ## 🌟 Credits and Acknowledgements
 
 - [swagger](https://github.com/majorgameapp): Main Developer

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "formatters",
+    Path(__file__).resolve().parents[1] / "ShrutiMusic" / "utils" / "formatters.py",
+)
+formatters = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(formatters)
+
+time_to_seconds = formatters.time_to_seconds
+seconds_to_min = formatters.seconds_to_min
+
+
+def test_time_to_seconds():
+    assert time_to_seconds("01:30") == 90
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (None, "-"),
+        (90, "01:30"),
+        (61, "01:01"),
+        (3661, "01:01:01"),
+        (90061, "01:01:01:01"),
+    ],
+)
+def test_seconds_to_min(seconds, expected):
+    assert seconds_to_min(seconds) == expected


### PR DESCRIPTION
## Summary
- add unit tests for `time_to_seconds` and `seconds_to_min`
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857337665808333972e2edc10afab12