### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/ShrutiMusic/__main__.py
+++ b/ShrutiMusic/__main__.py
@@ -43,7 +43,7 @@ async def init():
         await Aviax.stream_call("https://te.legra.ph/file/29f784eb49d230ab62e9e.mp4")
     except NoActiveGroupCall:
         LOGGER("ShrutiMusic").error(
-            "Please turn on the videochat of your log group\channel.\n\nStopping Bot..."
+            "Please turn on the videochat of your log group/channel.\n\nStopping Bot..."
         )
         exit()
     except:

--- a/ShrutiMusic/utils/thumbnails.py
+++ b/ShrutiMusic/utils/thumbnails.py
@@ -118,7 +118,7 @@ async def gen_thumb(videoid: str):
         for result in (await results.next())["result"]:
             title = result.get("title")
             if title:
-                title = re.sub("\W+", " ", title).title()
+                title = re.sub(r"\W+", " ", title).title()
             else:
                 title = "Unsupported Title"
             duration = result.get("duration")


### PR DESCRIPTION
## Summary
- use forward slash when printing the log group/channel message
- use a raw string for the regex used in thumbnail title cleanup

## Testing
- `pytest -q`
- `python -m compileall -q ShrutiMusic/__main__.py ShrutiMusic/utils/thumbnails.py && echo compiled`

------
https://chatgpt.com/codex/tasks/task_b_6857b6d3b8148333956645ee843d5e7c