### PR TITLE
Update start image and env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://files.catbox.moe/eehxb4.jpg" alt="˹ᴛʜᴇ sɪʀɪᴏɴ ʙᴏᴛ˼ Logo" width="500px">
+<img src="https://telegra.ph/file/74c2786ec467c233c3132.jpg" alt="˹ᴛʜᴇ sɪʀɪᴏɴ ʙᴏᴛ˼ Logo" width="500px">
 </p>
 
 <h1 align="center">🎵  ˹ᴛʜᴇ sɪʀɪᴏɴ ʙᴏᴛ˼  🎵</h1>
@@ -115,6 +115,7 @@ Fill in your:
 - `SESSION_STRING` (Generate using session generator bot)
 - `MUSIC_BOT_NAME` (your bot name)
 - `SUDO_USERS` (your user ID)
+- `START_IMG_URL` (image shown with /start)
 
 #### Starting the Bot
 
@@ -160,6 +161,7 @@ screen -r shrutibot
    - MUSIC_BOT_NAME
    - SESSION_STRING
    - SUDO_USERS (your User ID)
+   - START_IMG_URL
 3. Click "Deploy App"
 4. Once deployed, go to Resources tab and turn on the worker
 

--- a/config.py
+++ b/config.py
@@ -97,7 +97,7 @@ AUTO_LEAVING_ASSISTANT = bool(os.getenv("AUTO_LEAVING_ASSISTANT", False))
 # 🖼️ Image URLs (Can be customized)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-START_IMG_URL = os.getenv("START_IMG_URL", "https://files.catbox.moe/eehxb4.jpg")
+START_IMG_URL = os.getenv("START_IMG_URL", "https://telegra.ph/file/74c2786ec467c233c3132.jpg")
 PING_IMG_URL = os.getenv("PING_IMG_URL", "https://files.catbox.moe/eehxb4.jpg")
 PLAYLIST_IMG_URL = "https://files.catbox.moe/eehxb4.jpg"
 STATS_IMG_URL = "https://files.catbox.moe/eehxb4.jpg"

--- a/sample.env
+++ b/sample.env
@@ -32,6 +32,9 @@ SUPPORT_GROUP=
 # SUPPORT_CHANNEL: 📡 Support Channel URL
 SUPPORT_CHANNEL=
 
+# START_IMG_URL: 🖼️ Image URL for /start (optional)
+START_IMG_URL=
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
                      🛠️ 𝐂𝐫𝐞𝐝𝐢𝐭𝐬 & 𝐂𝐨𝐧𝐭𝐚𝐜𝐭 🛠️

--- a/setup
+++ b/setup
@@ -106,6 +106,7 @@ pprint "\nOWNER ID:"; color_reset; read ownid
 pprint "\nMONGO DB URI: "; color_reset; read mongo_db
 pprint "\nLOG GROUP ID: "; color_reset; read logger
 pprint "\nSTRING SESSION: "; color_reset; read string_session
+pprint "\nSTART IMAGE URL (optional): "; color_reset; read startimg
 
 pprint "\n\nProcessing your vars, wait a while !" "cgreen"
 
@@ -119,6 +120,7 @@ BOT_TOKEN = $bot_token
 MONGO_DB_URI = $mongo_db
 LOG_GROUP_ID = $logger
 STRING_SESSION = $string_session
+START_IMG_URL = $startimg
 OWNER_ID = $ownid""" > .env
 clear
 


### PR DESCRIPTION
## Summary
- update default start image in README and config
- document START_IMG_URL env var
- add START_IMG_URL to sample env
- extend setup script with START_IMG_URL prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c28079f788333933a7a2173dcc798