### PR TITLE
Refactor buttons and improve logging

### DIFF
--- a/OxygenMusic/plugins/bot/botlogs.py
+++ b/OxygenMusic/plugins/bot/botlogs.py
@@ -4,6 +4,7 @@ from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from config import LOG_GROUP_ID
 from OxygenMusic import app
 from OxygenMusic.utils.database import add_served_chat, get_assistant
+from OxygenMusic.logging import LOGGER
 
 welcome_photo = "https://files.catbox.moe/ajobub.jpg"  # Bot added image
 
@@ -53,4 +54,4 @@ async def join_watcher(_, message):
                     await userbot.join_chat(f"@{username}")
 
     except Exception as e:
-        print(f"Error: {e}")
+        LOGGER(__name__).exception("Error in join_watcher", exc_info=e)

--- a/OxygenMusic/plugins/bot/settings.py
+++ b/OxygenMusic/plugins/bot/settings.py
@@ -36,6 +36,7 @@ from OxygenMusic.utils.inline.settings import (
 )
 from OxygenMusic.utils.inline.start import private_panel
 from config import BANNED_USERS, OWNER_ID
+from OxygenMusic.logging import LOGGER
 
 
 @app.on_message(
@@ -190,7 +191,7 @@ async def addition(client, CallbackQuery, _):
     current = await get_upvote_count(CallbackQuery.message.chat.id)
     if mode == "M":
         final = current - 2
-        print(final)
+        LOGGER(__name__).debug("vote final: %s", final)
         if final == 0:
             return await CallbackQuery.answer(
                 _["setting_11"],
@@ -201,7 +202,7 @@ async def addition(client, CallbackQuery, _):
         await set_upvotes(CallbackQuery.message.chat.id, final)
     else:
         final = current + 2
-        print(final)
+        LOGGER(__name__).debug("vote final: %s", final)
         if final == 17:
             return await CallbackQuery.answer(
                 _["setting_12"],

--- a/OxygenMusic/plugins/bot/start.py
+++ b/OxygenMusic/plugins/bot/start.py
@@ -24,6 +24,7 @@ from OxygenMusic.utils import bot_sys_stats
 from OxygenMusic.utils.decorators.language import LanguageStart
 from OxygenMusic.utils.formatters import get_readable_time
 from OxygenMusic.utils.inline import help_pannel, private_panel, start_panel
+from OxygenMusic.logging import LOGGER
 from config import BANNED_USERS
 from strings import get_string
 
@@ -168,4 +169,4 @@ async def welcome(client, message: Message):
                     )
                     await message.reply_text(welcome)
         except Exception as ex:
-            print(ex)
+            LOGGER(__name__).exception("Error in start_pm", exc_info=ex)

--- a/OxygenMusic/plugins/play/live.py
+++ b/OxygenMusic/plugins/play/live.py
@@ -5,6 +5,7 @@ from OxygenMusic.utils.channelplay import get_channeplayCB
 from OxygenMusic.utils.decorators.language import languageCB
 from OxygenMusic.utils.stream.stream import stream
 from config import BANNED_USERS
+from OxygenMusic.logging import LOGGER
 
 
 @app.on_callback_query(filters.regex("LiveStream") & ~BANNED_USERS)
@@ -52,7 +53,7 @@ async def play_live_stream(client, CallbackQuery, _):
                 forceplay=ffplay,
             )
         except Exception as e:
-            print(f"Error: {e}")
+            LOGGER(__name__).exception("Error while streaming live", exc_info=e)
             ex_type = type(e).__name__
             err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
             return await mystic.edit_text(err)

--- a/OxygenMusic/plugins/play/play.py
+++ b/OxygenMusic/plugins/play/play.py
@@ -23,6 +23,7 @@ from OxygenMusic.utils.inline import (
 from OxygenMusic.utils.logger import play_logs
 from OxygenMusic.utils.stream.stream import stream
 from config import BANNED_USERS, lyrical
+from OxygenMusic.logging import LOGGER
 
 
 @app.on_message(
@@ -105,7 +106,7 @@ async def play_commnd(
                     forceplay=fplay,
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                LOGGER(__name__).exception("Error streaming telegram audio", exc_info=e)
                 ex_type = type(e).__name__
                 err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
                 return await mystic.edit_text(err)
@@ -150,7 +151,7 @@ async def play_commnd(
                     forceplay=fplay,
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                LOGGER(__name__).exception("Error streaming telegram video", exc_info=e)
                 ex_type = type(e).__name__
                 err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
                 return await mystic.edit_text(err)
@@ -284,7 +285,7 @@ async def play_commnd(
                     forceplay=fplay,
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                LOGGER(__name__).exception("Error streaming soundcloud", exc_info=e)
                 ex_type = type(e).__name__
                 err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
                 return await mystic.edit_text(err)
@@ -299,7 +300,7 @@ async def play_commnd(
                     text=_["play_17"],
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                LOGGER(__name__).exception("Error during stream_call", exc_info=e)
                 return await mystic.edit_text(_["general_2"].format(type(e).__name__))
             await mystic.edit_text(_["str_2"])
             try:
@@ -316,7 +317,7 @@ async def play_commnd(
                     forceplay=fplay,
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                LOGGER(__name__).exception("Error streaming index link", exc_info=e)
                 ex_type = type(e).__name__
                 err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
                 return await mystic.edit_text(err)
@@ -373,7 +374,7 @@ async def play_commnd(
                 forceplay=fplay,
             )
         except Exception as e:
-            print(f"Error: {e}")
+            LOGGER(__name__).exception("Error streaming directly", exc_info=e)
             ex_type = type(e).__name__
             err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
             return await mystic.edit_text(err)
@@ -501,7 +502,7 @@ async def play_music(client, CallbackQuery, _):
             forceplay=ffplay,
         )
     except Exception as e:
-        print(f"Error: {e}")
+        LOGGER(__name__).exception("Error while playing from callback", exc_info=e)
         ex_type = type(e).__name__
         err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
         return await mystic.edit_text(err)
@@ -600,7 +601,7 @@ async def play_playlists_command(client, CallbackQuery, _):
             forceplay=ffplay,
         )
     except Exception as e:
-        print(f"Error: {e}")
+        LOGGER(__name__).exception("Error while streaming playlist", exc_info=e)
         ex_type = type(e).__name__
         err = e if ex_type == "AssistantErr" else _["general_2"].format(ex_type)
         return await mystic.edit_text(err)

--- a/OxygenMusic/plugins/tools/dev.py
+++ b/OxygenMusic/plugins/tools/dev.py
@@ -12,6 +12,7 @@ from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from OxygenMusic import app
 from config import OWNER_ID
+from OxygenMusic.logging import LOGGER
 
 
 async def aexec(code, client, message):
@@ -181,7 +182,7 @@ async def shellrunner(_, message: Message):
                 stderr=subprocess.PIPE,
             )
         except Exception as err:
-            print(err)
+            LOGGER(__name__).exception(err)
             exc_type, exc_obj, exc_tb = sys.exc_info()
             errors = traceback.format_exception(
                 etype=exc_type,

--- a/OxygenMusic/utils/inline/__init__.py
+++ b/OxygenMusic/utils/inline/__init__.py
@@ -5,3 +5,4 @@ from .queue import *
 from .settings import *
 from .speed import *
 from .start import *
+from .keyboard import build_inline_keyboard

--- a/OxygenMusic/utils/inline/keyboard.py
+++ b/OxygenMusic/utils/inline/keyboard.py
@@ -1,0 +1,41 @@
+from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from typing import Iterable, List, Tuple, Union
+
+Button = Union[
+    Tuple[str, str],  # text, callback_data
+    Tuple[str, str, bool],  # text, data, is_url
+    Tuple[str, str, str],  # text, data, type: 'url', 'user', 'callback'
+]
+
+
+def build_inline_keyboard(rows: Iterable[Iterable[Button]]) -> InlineKeyboardMarkup:
+    """Return InlineKeyboardMarkup from rows of button tuples.
+
+    Supported tuple formats:
+    - (text, callback_data)
+    - (text, data, True)  -> treat data as URL
+    - (text, data, "url"|"callback"|"user") to explicitly set type
+    """
+    keyboard: List[List[InlineKeyboardButton]] = []
+    for row in rows:
+        btn_row: List[InlineKeyboardButton] = []
+        for item in row:
+            if len(item) == 2:
+                text, data = item
+                btn_row.append(InlineKeyboardButton(text=text, callback_data=data))
+            elif len(item) == 3 and isinstance(item[2], bool):
+                text, data, is_url = item
+                if is_url:
+                    btn_row.append(InlineKeyboardButton(text=text, url=data))
+                else:
+                    btn_row.append(InlineKeyboardButton(text=text, callback_data=data))
+            else:
+                text, data, kind = item
+                if kind == "url":
+                    btn_row.append(InlineKeyboardButton(text=text, url=data))
+                elif kind == "user":
+                    btn_row.append(InlineKeyboardButton(text=text, user_id=int(data)))
+                else:
+                    btn_row.append(InlineKeyboardButton(text=text, callback_data=data))
+        keyboard.append(btn_row)
+    return InlineKeyboardMarkup(keyboard)

--- a/OxygenMusic/utils/inline/start.py
+++ b/OxygenMusic/utils/inline/start.py
@@ -1,45 +1,32 @@
-from pyrogram.types import InlineKeyboardButton
 import config
 from OxygenMusic import app
+from .keyboard import build_inline_keyboard
 
 def start_panel(_):
-    buttons = [
+    return build_inline_keyboard(
         [
-            InlineKeyboardButton(
-                text=_["S_B_1"], url=f"https://t.me/{app.username}?startgroup=true"
+            (
+                (_["S_B_1"], f"https://t.me/{app.username}?startgroup=true", True),
+                (_["S_B_2"], config.SUPPORT_GROUP, True),
             ),
-            InlineKeyboardButton(text=_["S_B_2"], url=config.SUPPORT_GROUP),
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_10"], url="https://t.me/oxeign"),
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_7"], url="https://t.me/TeamSirion"),
-        ],
-    ]
-    return buttons
+            ((_["S_B_10"], "https://t.me/oxeign", True),),
+            ((_["S_B_7"], "https://t.me/TeamSirion", True),),
+        ]
+    )
 
 def private_panel(_):
-    buttons = [
+    return build_inline_keyboard(
         [
-            InlineKeyboardButton(
-                text=_["S_B_3"],
-                url=f"https://t.me/{app.username}?startgroup=true",
-            )
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_4"], callback_data="settings_back_helper"),
-            InlineKeyboardButton(text=_["S_B_2"], url=config.SUPPORT_GROUP),
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_6"], url=config.SUPPORT_CHANNEL),
-            InlineKeyboardButton(text=_["S_B_5"], user_id=config.OWNER_ID),
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_10"], url="https://t.me/oxeign"),
-        ],
-        [
-            InlineKeyboardButton(text=_["S_B_7"], url="https://t.me/TeamSirion"),
-        ],
-    ]
-    return buttons
+            ((_["S_B_3"], f"https://t.me/{app.username}?startgroup=true", True),),
+            (
+                (_["S_B_4"], "settings_back_helper"),
+                (_["S_B_2"], config.SUPPORT_GROUP, True),
+            ),
+            (
+                (_["S_B_6"], config.SUPPORT_CHANNEL, True),
+                (_["S_B_5"], str(config.OWNER_ID), "user"),
+            ),
+            ((_["S_B_10"], "https://t.me/oxeign", True),),
+            ((_["S_B_7"], "https://t.me/TeamSirion", True),),
+        ]
+    )


### PR DESCRIPTION
## Summary
- introduce `build_inline_keyboard` utility for clean inline keyboard creation
- use the new keyboard builder in start panel helpers
- replace remaining print statements with proper logging
- add logging imports where needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c46d71a3883338cd393bf2baf4d07