### PR TITLE
Fix lint errors

### DIFF
--- a/OxygenMusic/plugins/bot/settings.py
+++ b/OxygenMusic/plugins/bot/settings.py
@@ -78,7 +78,6 @@ async def settings_back_markup(client, CallbackQuery: CallbackQuery, _):
         pass
     if CallbackQuery.message.chat.type == ChatType.PRIVATE:
         await app.resolve_peer(OWNER_ID)
-        OWNER = OWNER_ID
         buttons = private_panel(_)
         UP, CPU, RAM, DISK = await bot_sys_stats()
         return await CallbackQuery.edit_message_text(
@@ -372,7 +371,6 @@ async def authusers_mar(client, CallbackQuery, _):
 @app.on_callback_query(filters.regex("VOMODECHANGE") & ~BANNED_USERS)
 @ActualAdminCB
 async def vote_change(client, CallbackQuery, _):
-    command = CallbackQuery.matches[0].group(1)
     try:
         await CallbackQuery.answer(_["set_cb_3"], show_alert=True)
     except:

--- a/OxygenMusic/plugins/bot/start.py
+++ b/OxygenMusic/plugins/bot/start.py
@@ -157,7 +157,7 @@ async def welcome(client, message: Message):
                 await message.stop_propagation()
             else:
                 if await is_vip_user(member.id):
-                    stats = await get_vip_user(member.id)
+                    await get_vip_user(member.id)
                     plays = user_play_count.get(member.id, 0)
                     welcome = (
                         f"🎉 Welcome back, DJ {member.mention}!\n"

--- a/OxygenMusic/plugins/misc/autoleave.py
+++ b/OxygenMusic/plugins/misc/autoleave.py
@@ -69,9 +69,8 @@ async def auto_end():
                     nocall = True
                 except Exception:
                     users = 100
-                timer = autoend.get(chat_id)
                 if users == 1:
-                    res = await set_loop(chat_id, 0)
+                    await set_loop(chat_id, 0)
                     keys_to_remove.append(chat_id)
                     try:
                         await db[chat_id][0]["mystic"].delete()

--- a/OxygenMusic/plugins/misc/broadcast.py
+++ b/OxygenMusic/plugins/misc/broadcast.py
@@ -89,8 +89,11 @@ async def braodcast_message(client, message, _):
     if message.reply_to_message:
         x = message.reply_to_message.id
         y = message.chat.id
-        reply_markup = message.reply_to_message.reply_markup if message.reply_to_message.reply_markup else None
-        content = None
+        reply_markup = (
+            message.reply_to_message.reply_markup
+            if message.reply_to_message.reply_markup
+            else None
+        )
     else:
         if len(message.command) < 2:
             return await message.reply_text(_["broad_2"])

--- a/OxygenMusic/plugins/play/play.py
+++ b/OxygenMusic/plugins/play/play.py
@@ -8,7 +8,7 @@ from pytgcalls.exceptions import NoActiveGroupCall
 import config
 from OxygenMusic import Apple, Resso, SoundCloud, Spotify, Telegram, YouTube, app
 from OxygenMusic.core.call import Aviax
-from OxygenMusic.utils import seconds_to_min, time_to_seconds
+from OxygenMusic.utils import time_to_seconds
 from OxygenMusic.utils.channelplay import get_channeplayCB
 from OxygenMusic.utils.decorators.language import languageCB
 from OxygenMusic.utils.decorators.play import PlayWrapper
@@ -76,7 +76,6 @@ async def play_commnd(
     if audio_telegram:
         if audio_telegram.file_size > 104857600:
             return await mystic.edit_text(_["play_5"])
-        duration_min = seconds_to_min(audio_telegram.duration)
         if (audio_telegram.duration) > config.DURATION_LIMIT:
             return await mystic.edit_text(
                 _["play_6"].format(config.DURATION_LIMIT_MIN, app.mention)

--- a/OxygenMusic/plugins/play/playmode.py
+++ b/OxygenMusic/plugins/play/playmode.py
@@ -27,7 +27,7 @@ async def playmode_(client, message: Message, _):
     else:
         Playtype = True
     buttons = playmode_users_markup(_, Direct, Group, Playtype)
-    response = await message.reply_text(
+    await message.reply_text(
         _["play_22"].format(message.chat.title),
         reply_markup=InlineKeyboardMarkup(buttons),
     )

--- a/OxygenMusic/plugins/tools/speedtest.py
+++ b/OxygenMusic/plugins/tools/speedtest.py
@@ -41,5 +41,5 @@ async def speedtest_function(client, message: Message, _):
         result["server"]["latency"],
         result["ping"],
     )
-    msg = await message.reply_photo(photo=result["share"], caption=output)
+    await message.reply_photo(photo=result["share"], caption=output)
     await m.delete()

--- a/OxygenMusic/utils/__init__.py
+++ b/OxygenMusic/utils/__init__.py
@@ -1,8 +1,8 @@
-from .channelplay import *
-from .database import *
-from .decorators import *
-from .extraction import *
-from .formatters import *
-from .inline import *
-from .pastebin import *
-from .sys import *
+from .channelplay import *  # noqa: F403
+from .database import *  # noqa: F403
+from .decorators import *  # noqa: F403
+from .extraction import *  # noqa: F403
+from .formatters import *  # noqa: F403
+from .inline import *  # noqa: F403
+from .pastebin import *  # noqa: F403
+from .sys import *  # noqa: F403

--- a/OxygenMusic/utils/decorators/__init__.py
+++ b/OxygenMusic/utils/decorators/__init__.py
@@ -1,2 +1,2 @@
-from .admins import *
-from .language import *
+from .admins import *  # noqa: F403
+from .language import *  # noqa: F403

--- a/OxygenMusic/utils/decorators/language.py
+++ b/OxygenMusic/utils/decorators/language.py
@@ -1,3 +1,4 @@
+from OxygenMusic import app
 from OxygenMusic.misc import SUDOERS
 from OxygenMusic.utils.database import get_lang, is_maintenance
 from config import SUPPORT_GROUP

--- a/OxygenMusic/utils/inline/__init__.py
+++ b/OxygenMusic/utils/inline/__init__.py
@@ -1,8 +1,10 @@
-from .extras import *
-from .help import *
-from .play import *
-from .queue import *
-from .settings import *
-from .speed import *
-from .start import *
+from .extras import *  # noqa: F403
+from .help import *  # noqa: F403
+from .play import *  # noqa: F403
+from .queue import *  # noqa: F403
+from .settings import *  # noqa: F403
+from .speed import *  # noqa: F403
+from .start import *  # noqa: F403
 from .keyboard import build_inline_keyboard
+
+__all__ = ["build_inline_keyboard"]

--- a/OxygenMusic/utils/inline/settings.py
+++ b/OxygenMusic/utils/inline/settings.py
@@ -27,7 +27,7 @@ def vote_mode_markup(_, current, mode: Union[bool, str] = None):
         [
             InlineKeyboardButton(text="Vᴏᴛɪɴɢ ᴍᴏᴅᴇ ➜", callback_data="VOTEANSWER"),
             InlineKeyboardButton(
-                text=_["ST_B_5"] if mode == True else _["ST_B_6"],
+                text=_["ST_B_5"] if mode else _["ST_B_6"],
                 callback_data="VOMODECHANGE",
             ),
         ],
@@ -55,7 +55,7 @@ def auth_users_markup(_, status: Union[bool, str] = None):
         [
             InlineKeyboardButton(text=_["ST_B_7"], callback_data="AUTHANSWER"),
             InlineKeyboardButton(
-                text=_["ST_B_8"] if status == True else _["ST_B_9"],
+                text=_["ST_B_8"] if status else _["ST_B_9"],
                 callback_data="AUTH",
             ),
         ],
@@ -83,21 +83,21 @@ def playmode_users_markup(
         [
             InlineKeyboardButton(text=_["ST_B_10"], callback_data="SEARCHANSWER"),
             InlineKeyboardButton(
-                text=_["ST_B_11"] if Direct == True else _["ST_B_12"],
+                text=_["ST_B_11"] if Direct else _["ST_B_12"],
                 callback_data="MODECHANGE",
             ),
         ],
         [
             InlineKeyboardButton(text=_["ST_B_13"], callback_data="AUTHANSWER"),
             InlineKeyboardButton(
-                text=_["ST_B_8"] if Group == True else _["ST_B_9"],
+                text=_["ST_B_8"] if Group else _["ST_B_9"],
                 callback_data="CHANNELMODECHANGE",
             ),
         ],
         [
             InlineKeyboardButton(text=_["ST_B_14"], callback_data="PLAYTYPEANSWER"),
             InlineKeyboardButton(
-                text=_["ST_B_8"] if Playtype == True else _["ST_B_9"],
+                text=_["ST_B_8"] if Playtype else _["ST_B_9"],
                 callback_data="PLAYTYPECHANGE",
             ),
         ],


### PR DESCRIPTION
## Summary
- fix flake warnings by removing unused vars
- annotate wildcard imports to satisfy ruff
- drop equality comparisons to True in settings
- ensure `app` imported for decorators

## Testing
- `pytest -q`
- `ruff check --select F . | head`


------
https://chatgpt.com/codex/tasks/task_b_685c4e057c408333be8c6b85148f3ec3