### PR TITLE
Fix ping with no assistants

### DIFF
--- a/OxygenMusic/core/call.py
+++ b/OxygenMusic/core/call.py
@@ -553,6 +553,8 @@ class Call(PyTgCalls):
             pings.append(await self.four.ping)
         if config.STRING5:
             pings.append(await self.five.ping)
+        if not pings:
+            return "0"
         return str(round(sum(pings) / len(pings), 3))
 
     async def start(self):


### PR DESCRIPTION
## Summary
- avoid division by zero in ping calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c53d9183c8333ae1f6b3ee2f7d3b6