### PR TITLE
Fix db import error

### DIFF
--- a/OxygenMusic/misc.py
+++ b/OxygenMusic/misc.py
@@ -9,6 +9,12 @@ from OxygenMusic.core.mongo import mongodb
 
 from .logging import LOGGER
 
+# In-memory database placeholder. This dictionary will be
+# initialised by ``dbb()`` during bootstrap, but needs to be
+# present at import time so that other modules can safely
+# import ``db`` from here without hitting ``ImportError``.
+db = {}
+
 SUDOERS = filters.user()
 
 HAPP = None


### PR DESCRIPTION
## Summary
- avoid ImportError by defining `db` placeholder in `misc.py`
- leave bootstrap logic unchanged (initialises `db` in-memory)

## Testing
- `pip install -q -r requirements.txt` *(fails: environment has no network access)*
- `python3 run.py` *(fails: Assistant client variables not defined)*

------
https://chatgpt.com/codex/tasks/task_b_685eb286a4f08329ab78521bfd299314