### PR TITLE
Improve init and bootstrap handling

### DIFF
--- a/OxygenMusic/plugins/misc/broadcast.py
+++ b/OxygenMusic/plugins/misc/broadcast.py
@@ -6,7 +6,7 @@ from pyrogram.errors import FloodWait
 
 from config import adminlist
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import (get_active_chats, get_authuser_names,
                                         get_client, get_served_chats,
                                         get_served_users)
@@ -20,7 +20,7 @@ IS_BROADCASTING = False
 
 
 @app.on_message(
-    filters.command("broadcast") & (filters.user(BROADCAST_ALLOWED_IDS) | SUDOERS)
+    filters.command("broadcast") & (filters.user(BROADCAST_ALLOWED_IDS) | SUDOERS_FILTER)
 )
 @language
 async def braodcast_message(client, message, _):

--- a/OxygenMusic/plugins/misc/vcnotify.py
+++ b/OxygenMusic/plugins/misc/vcnotify.py
@@ -2,14 +2,14 @@ from pyrogram import filters
 from pyrogram.types import Message
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import add_off, add_on, get_lang, is_on_off
 from strings import get_string
 
 VCNOTIFY_ID = 3
 
 
-@app.on_message(filters.command(["vcnotify"]) & SUDOERS)
+@app.on_message(filters.command(["vcnotify"]) & SUDOERS_FILTER)
 async def vcnotify_toggle(client, message: Message):
     language = await get_lang(message.chat.id)
     _ = get_string(language)

--- a/OxygenMusic/plugins/sudo/autoend.py
+++ b/OxygenMusic/plugins/sudo/autoend.py
@@ -2,11 +2,11 @@ from pyrogram import filters
 from pyrogram.types import Message
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import autoend_off, autoend_on, is_autoend
 
 
-@app.on_message(filters.command("autoend") & SUDOERS)
+@app.on_message(filters.command("autoend") & SUDOERS_FILTER)
 async def auto_end_stream(_, message: Message):
     zerostate = await is_autoend()
     usage = f"<b>ᴇxᴀᴍᴘʟᴇ :</b>\n\n/autoend [ᴇɴᴀʙʟᴇ | ᴅɪsᴀʙʟᴇ]\n\n Current state : {zerostate}"

--- a/OxygenMusic/plugins/sudo/blchat.py
+++ b/OxygenMusic/plugins/sudo/blchat.py
@@ -3,13 +3,13 @@ from pyrogram.types import Message
 
 from config import BANNED_USERS
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import (blacklist_chat, blacklisted_chats,
                                         whitelist_chat)
 from OxygenMusic.utils.decorators.language import language
 
 
-@app.on_message(filters.command(["blchat", "blacklistchat"]) & SUDOERS)
+@app.on_message(filters.command(["blchat", "blacklistchat"]) & SUDOERS_FILTER)
 @language
 async def blacklist_chat_func(client, message: Message, _):
     if len(message.command) != 2:
@@ -29,7 +29,7 @@ async def blacklist_chat_func(client, message: Message, _):
 
 
 @app.on_message(
-    filters.command(["whitelistchat", "unblacklistchat", "unblchat"]) & SUDOERS
+    filters.command(["whitelistchat", "unblacklistchat", "unblchat"]) & SUDOERS_FILTER
 )
 @language
 async def white_funciton(client, message: Message, _):

--- a/OxygenMusic/plugins/sudo/block.py
+++ b/OxygenMusic/plugins/sudo/block.py
@@ -3,13 +3,13 @@ from pyrogram.types import Message
 
 from config import BANNED_USERS
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER, SUDOERS
 from OxygenMusic.utils.database import add_gban_user, remove_gban_user
 from OxygenMusic.utils.decorators.language import language
 from OxygenMusic.utils.extraction import extract_user
 
 
-@app.on_message(filters.command(["block"]) & SUDOERS)
+@app.on_message(filters.command(["block"]) & SUDOERS_FILTER)
 @language
 async def useradd(client, message: Message, _):
     if not message.reply_to_message:
@@ -23,7 +23,7 @@ async def useradd(client, message: Message, _):
     await message.reply_text(_["block_2"].format(user.mention))
 
 
-@app.on_message(filters.command(["unblock"]) & SUDOERS)
+@app.on_message(filters.command(["unblock"]) & SUDOERS_FILTER)
 @language
 async def userdel(client, message: Message, _):
     if not message.reply_to_message:
@@ -37,7 +37,7 @@ async def userdel(client, message: Message, _):
     await message.reply_text(_["block_4"].format(user.mention))
 
 
-@app.on_message(filters.command(["blocked", "blockedusers", "blusers"]) & SUDOERS)
+@app.on_message(filters.command(["blocked", "blockedusers", "blusers"]) & SUDOERS_FILTER)
 @language
 async def sudoers_list(client, message: Message, _):
     if not BANNED_USERS:

--- a/OxygenMusic/plugins/sudo/gban.py
+++ b/OxygenMusic/plugins/sudo/gban.py
@@ -6,7 +6,7 @@ from pyrogram.types import Message
 
 from config import BANNED_USERS
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS, SUDOERS_FILTER
 from OxygenMusic.utils import get_readable_time
 from OxygenMusic.utils.database import (add_banned_user, get_banned_count,
                                         get_banned_users, get_served_chats,
@@ -15,7 +15,7 @@ from OxygenMusic.utils.decorators.language import language
 from OxygenMusic.utils.extraction import extract_user
 
 
-@app.on_message(filters.command(["gban", "globalban"]) & SUDOERS)
+@app.on_message(filters.command(["gban", "globalban"]) & SUDOERS_FILTER)
 @language
 async def global_ban(client, message: Message, _):
     if not message.reply_to_message:
@@ -63,7 +63,7 @@ async def global_ban(client, message: Message, _):
     await mystic.delete()
 
 
-@app.on_message(filters.command(["ungban"]) & SUDOERS)
+@app.on_message(filters.command(["ungban"]) & SUDOERS_FILTER)
 @language
 async def global_un(client, message: Message, _):
     if not message.reply_to_message:
@@ -95,7 +95,7 @@ async def global_un(client, message: Message, _):
     await mystic.delete()
 
 
-@app.on_message(filters.command(["gbannedusers", "gbanlist"]) & SUDOERS)
+@app.on_message(filters.command(["gbannedusers", "gbanlist"]) & SUDOERS_FILTER)
 @language
 async def gbanned_list(client, message: Message, _):
     counts = await get_banned_count()

--- a/OxygenMusic/plugins/sudo/logger.py
+++ b/OxygenMusic/plugins/sudo/logger.py
@@ -1,12 +1,12 @@
 from pyrogram import filters
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import add_off, add_on
 from OxygenMusic.utils.decorators.language import language
 
 
-@app.on_message(filters.command(["logger"]) & SUDOERS)
+@app.on_message(filters.command(["logger"]) & SUDOERS_FILTER)
 @language
 async def logger(client, message, _):
     usage = _["log_1"]
@@ -23,7 +23,7 @@ async def logger(client, message, _):
         await message.reply_text(usage)
 
 
-@app.on_message(filters.command(["cookies"]) & SUDOERS)
+@app.on_message(filters.command(["cookies"]) & SUDOERS_FILTER)
 @language
 async def send_logs(client, message, _):
     """Send the cookie logging CSV file."""

--- a/OxygenMusic/plugins/sudo/maintenance.py
+++ b/OxygenMusic/plugins/sudo/maintenance.py
@@ -2,13 +2,13 @@ from pyrogram import filters
 from pyrogram.types import Message
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import (get_lang, is_maintenance,
                                         maintenance_off, maintenance_on)
 from strings import get_string
 
 
-@app.on_message(filters.command(["maintenance"]) & SUDOERS)
+@app.on_message(filters.command(["maintenance"]) & SUDOERS_FILTER)
 async def maintenance(client, message: Message):
     try:
         language = await get_lang(message.chat.id)

--- a/OxygenMusic/plugins/sudo/restart.py
+++ b/OxygenMusic/plugins/sudo/restart.py
@@ -11,7 +11,7 @@ from pyrogram import filters
 
 import config
 from OxygenMusic import app
-from OxygenMusic.misc import HAPP, SUDOERS, XCB
+from OxygenMusic.misc import HAPP, SUDOERS_FILTER, XCB
 from OxygenMusic.utils.database import (get_active_chats, remove_active_chat,
                                         remove_active_video_chat)
 from OxygenMusic.utils.decorators.language import language
@@ -24,7 +24,7 @@ async def is_heroku():
     return "heroku" in socket.getfqdn()
 
 
-@app.on_message(filters.command(["getlog", "logs", "getlogs"]) & SUDOERS)
+@app.on_message(filters.command(["getlog", "logs", "getlogs"]) & SUDOERS_FILTER)
 @language
 async def log_(client, message, _):
     try:
@@ -33,7 +33,7 @@ async def log_(client, message, _):
         await message.reply_text(_["server_1"])
 
 
-@app.on_message(filters.command(["update", "gitpull"]) & SUDOERS)
+@app.on_message(filters.command(["update", "gitpull"]) & SUDOERS_FILTER)
 @language
 async def update_(client, message, _):
     if await is_heroku():
@@ -107,7 +107,7 @@ async def update_(client, message, _):
         exit()
 
 
-@app.on_message(filters.command(["restart"]) & SUDOERS)
+@app.on_message(filters.command(["restart"]) & SUDOERS_FILTER)
 async def restart_(_, message):
     response = await message.reply_text("ʀᴇsᴛᴀʀᴛɪɴɢ...")
     ac_chats = await get_active_chats()

--- a/OxygenMusic/plugins/tools/active.py
+++ b/OxygenMusic/plugins/tools/active.py
@@ -3,14 +3,14 @@ from pyrogram.types import Message
 from unidecode import unidecode
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.database import (get_active_chats,
                                         get_active_video_chats,
                                         remove_active_chat,
                                         remove_active_video_chat)
 
 
-@app.on_message(filters.command(["activevc", "activevoice"]) & SUDOERS)
+@app.on_message(filters.command(["activevc", "activevoice"]) & SUDOERS_FILTER)
 async def activevc(_, message: Message):
     mystic = await message.reply_text("» ɢᴇᴛᴛɪɴɢ ᴀᴄᴛɪᴠᴇ ᴠᴏɪᴄᴇ ᴄʜᴀᴛs ʟɪsᴛ...")
     served_chats = await get_active_chats()
@@ -42,7 +42,7 @@ async def activevc(_, message: Message):
         )
 
 
-@app.on_message(filters.command(["activev", "activevideo"]) & SUDOERS)
+@app.on_message(filters.command(["activev", "activevideo"]) & SUDOERS_FILTER)
 async def activevi_(_, message: Message):
     mystic = await message.reply_text("» ɢᴇᴛᴛɪɴɢ ᴀᴄᴛɪᴠᴇ ᴠɪᴅᴇᴏ ᴄʜᴀᴛs ʟɪsᴛ...")
     served_chats = await get_active_video_chats()

--- a/OxygenMusic/plugins/tools/speedtest.py
+++ b/OxygenMusic/plugins/tools/speedtest.py
@@ -5,7 +5,7 @@ from pyrogram import filters
 from pyrogram.types import Message
 
 from OxygenMusic import app
-from OxygenMusic.misc import SUDOERS
+from OxygenMusic.misc import SUDOERS_FILTER
 from OxygenMusic.utils.decorators.language import language
 
 
@@ -25,7 +25,7 @@ def testspeed(m, _):
     return result
 
 
-@app.on_message(filters.command(["speedtest", "spt"]) & SUDOERS)
+@app.on_message(filters.command(["speedtest", "spt"]) & SUDOERS_FILTER)
 @language
 async def speedtest_function(client, message: Message, _):
     m = await message.reply_text(_["server_11"])

--- a/run.py
+++ b/run.py
@@ -1,20 +1,29 @@
 import asyncio
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import OxygenMusic
 from OxygenMusic.bootstrap import bootstrap
+from OxygenMusic.logging import LOGGER
 
 
 if __name__ == "__main__":
-    (
-        OxygenMusic.app,
-        OxygenMusic.userbot,
-        OxygenMusic.Apple,
-        OxygenMusic.Carbon,
-        OxygenMusic.SoundCloud,
-        OxygenMusic.Spotify,
-        OxygenMusic.Resso,
-        OxygenMusic.YouTube,
-        OxygenMusic.Telegram,
-    ) = bootstrap()
+    try:
+        (
+            OxygenMusic.app,
+            OxygenMusic.userbot,
+            OxygenMusic.Apple,
+            OxygenMusic.Carbon,
+            OxygenMusic.SoundCloud,
+            OxygenMusic.Spotify,
+            OxygenMusic.Resso,
+            OxygenMusic.YouTube,
+            OxygenMusic.Telegram,
+        ) = bootstrap()
+    except Exception:
+        LOGGER(__name__).exception("Failed during bootstrap")
+        raise
 
     from OxygenMusic.__main__ import init
 


### PR DESCRIPTION
## Summary
- lazily import heavy dependencies in misc
- convert sudo list to a simple set and update related plugins
- initialize in-memory DB early
- load `.env` at startup and catch bootstrap errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eb7184c3083299fa4d035495ae7f5