### PR TITLE
Fix filters for dynamic sets

### DIFF
--- a/OxygenMusic/misc.py
+++ b/OxygenMusic/misc.py
@@ -16,7 +16,7 @@ db = {}
 # references a Pyrogram filter built from that set.  Mutating ``SUDOERS``
 # will automatically affect the filter.
 SUDOERS = set()
-SUDOERS_FILTER = filters.user(SUDOERS)
+SUDOERS_FILTER = filters.user(list(SUDOERS))
 
 HAPP = None
 _boot_ = time.time()
@@ -67,7 +67,7 @@ async def sudo():
     if sudoers:
         for user_id in sudoers:
             SUDOERS.add(user_id)
-    SUDOERS_FILTER = filters.user(SUDOERS)
+    SUDOERS_FILTER = filters.user(list(SUDOERS))
     LOGGER(__name__).info("Sudoers Loaded.")
 
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,18 @@ import re
 from dotenv import load_dotenv
 from pyrogram import filters
 
+
+class BannedUsers(set):
+    """Maintain a set of banned user IDs while behaving like a Pyrogram filter."""
+
+    def __invert__(self):
+        """Return the inverted Pyrogram filter for these users."""
+        return ~filters.user(list(self))
+
+    def filter(self):
+        """Return a Pyrogram filter matching these users."""
+        return filters.user(list(self))
+
 load_dotenv()
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -118,7 +130,7 @@ SPOTIFY_PLAYLIST_IMG_URL = "https://files.catbox.moe/eehxb4.jpg"
 # 🔐 User & Bot State Stores
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-BANNED_USERS = filters.user()
+BANNED_USERS = BannedUsers()
 adminlist = {}
 lyrical = {}
 votemode = {}


### PR DESCRIPTION
## Summary
- ensure banned user IDs remain usable as a filter
- guard against `TypeError: unhashable type: 'set'` in sudo logic

## Testing
- `bash fast_check.sh`

------
https://chatgpt.com/codex/tasks/task_b_685ec86059e88329a51038f6c42db16b