### PR TITLE
Fix asyncio loop usage

### DIFF
--- a/OxygenMusic/__main__.py
+++ b/OxygenMusic/__main__.py
@@ -60,4 +60,4 @@ async def init():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(init())
+    asyncio.run(init())

--- a/OxygenMusic/core/call.py
+++ b/OxygenMusic/core/call.py
@@ -177,7 +177,8 @@ class Call(PyTgCalls):
                 pass
         else:
             out = file_path
-        dur = await asyncio.get_event_loop().run_in_executor(None, check_duration, out)
+        loop = asyncio.get_running_loop()
+        dur = await loop.run_in_executor(None, check_duration, out)
         dur = int(dur)
         played, con_seconds = speed_converter(playing[0]["played"], speed)
         duration = seconds_to_min(dur)

--- a/OxygenMusic/core/git.py
+++ b/OxygenMusic/core/git.py
@@ -26,7 +26,7 @@ def install_req(cmd: str) -> Tuple[str, str, int, int]:
             process.pid,
         )
 
-    return asyncio.get_event_loop().run_until_complete(install_requirements())
+    return asyncio.run(install_requirements())
 
 
 def git():

--- a/OxygenMusic/platforms/Telegram.py
+++ b/OxygenMusic/platforms/Telegram.py
@@ -54,7 +54,8 @@ class TeleAPI:
             dur = seconds_to_min(filex.duration)
         except Exception:
             try:
-                dur = await asyncio.get_event_loop().run_in_executor(
+                loop = asyncio.get_running_loop()
+                dur = await loop.run_in_executor(
                     None, check_duration, file_path
                 )
                 dur = seconds_to_min(dur)

--- a/OxygenMusic/plugins/tools/speedtest.py
+++ b/OxygenMusic/plugins/tools/speedtest.py
@@ -29,7 +29,7 @@ def testspeed(m, _):
 @language
 async def speedtest_function(client, message: Message, _):
     m = await message.reply_text(_["server_11"])
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     result = await loop.run_in_executor(None, testspeed, m, _)
     output = _["server_15"].format(
         result["client"]["isp"],

--- a/OxygenMusic/utils/stream/queue.py
+++ b/OxygenMusic/utils/stream/queue.py
@@ -60,7 +60,8 @@ async def put_queue_index(
 ):
     if "20.212.146.162" in vidid:
         try:
-            dur = await asyncio.get_event_loop().run_in_executor(
+            loop = asyncio.get_running_loop()
+            dur = await loop.run_in_executor(
                 None, check_duration, vidid
             )
             duration = seconds_to_min(dur)

--- a/oxeignmusic.py
+++ b/oxeignmusic.py
@@ -3,4 +3,4 @@ import asyncio
 from OxygenMusic.__main__ import init
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(init())
+    asyncio.run(init())


### PR DESCRIPTION
## Summary
- modernize event loop management for Python 3.10+
- use `asyncio.run` instead of `get_event_loop().run_until_complete`
- switch to `get_running_loop` when scheduling executors

## Testing
- `ruff check OxygenMusic/__main__.py oxeignmusic.py OxygenMusic/core/git.py OxygenMusic/plugins/tools/speedtest.py OxygenMusic/utils/stream/queue.py OxygenMusic/platforms/Telegram.py OxygenMusic/core/call.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f89e5cce4832987d7f84b34f1fe23