### PR TITLE
Fix env var loading

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,10 +1,13 @@
 import asyncio
+from pathlib import Path
 from dotenv import load_dotenv
-import OxygenMusic
-from OxygenMusic.bootstrap import bootstrap
-from OxygenMusic.logging import LOGGER
 
-load_dotenv()
+# Load environment variables from .env before importing any project modules
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+import OxygenMusic  # noqa: E402
+from OxygenMusic.bootstrap import bootstrap  # noqa: E402
+from OxygenMusic.logging import LOGGER  # noqa: E402
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `.env` variables are loaded before importing project modules

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686012a383108329a0a19fe339b4aa6d